### PR TITLE
feat: persist session state in sqlite

### DIFF
--- a/src/app/session_idle.py
+++ b/src/app/session_idle.py
@@ -38,7 +38,7 @@ async def _check_and_finalize(user_id: str) -> None:
         await asyncio.sleep(IDLE_SECONDS)
 
         # pull current state
-        state: Optional[Tuple[BookingContext, SQLiteSession]] = get_state(user_id)
+        state: Optional[Tuple[BookingContext, SQLiteSession]] = await get_state(user_id)
         if not state:
             logger.info(f"idle: no state for {user_id}")
             return

--- a/src/app/state_manager.py
+++ b/src/app/state_manager.py
@@ -1,29 +1,123 @@
+"""Persistent state manager backed by SQLite.
+
+The previous implementation kept conversation state in a global
+dictionary.  This module stores state in a SQLite database so it can be
+shared across processes.  All helpers are asynchronous and use
+``asyncio.Lock`` together with ``asyncio.to_thread`` to perform the
+blocking SQLite operations without blocking the event loop.
+"""
+
 from __future__ import annotations
-from typing import Dict, Tuple, Optional
+
+import asyncio
+import json
+import sqlite3
+from dataclasses import asdict
+from typing import Optional, Tuple
+
 from agents import SQLiteSession
+
 from .context_models import BookingContext
 
-# simple in‑memory cache; replace with Redis later if you like
-_STATE: Dict[str, Tuple[BookingContext, SQLiteSession]] = {}
+# Path to the SQLite file used to persist state
+STATE_DB = "state.db"
+
+# Single lock protects concurrent access to the database
+_lock = asyncio.Lock()
 
 
-def get_state(user_id: str) -> Optional[Tuple[BookingContext, SQLiteSession]]:
-    return _STATE.get(user_id)
+def _ensure_table_sync() -> None:
+    conn = sqlite3.connect(STATE_DB)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS state (
+                user_id TEXT PRIMARY KEY,
+                ctx TEXT NOT NULL
+            )
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
-def touch_state(user_id: str, ctx: BookingContext, session: SQLiteSession) -> None:
-    _STATE[user_id] = (ctx, session)
+async def _ensure_table() -> None:
+    await asyncio.to_thread(_ensure_table_sync)
+
+
+async def get_state(
+    user_id: str,
+) -> Optional[Tuple[BookingContext, SQLiteSession]]:
+    """Retrieve stored context and create a session for ``user_id``."""
+    await _ensure_table()
+
+    async with _lock:
+        def _fetch() -> Optional[str]:
+            conn = sqlite3.connect(STATE_DB)
+            try:
+                cur = conn.execute(
+                    "SELECT ctx FROM state WHERE user_id = ?", (user_id,)
+                )
+                row = cur.fetchone()
+            finally:
+                conn.close()
+            return row[0] if row else None
+
+        ctx_json = await asyncio.to_thread(_fetch)
+
+    if ctx_json is None:
+        return None
+
+    ctx = BookingContext(**json.loads(ctx_json))
+    session = SQLiteSession(user_id, "noor_sessions.db")
+    return ctx, session
+
+
+async def touch_state(
+    user_id: str, ctx: BookingContext, session: SQLiteSession
+) -> None:
+    """Persist ``ctx`` for ``user_id``."""
+    await _ensure_table()
+    ctx_json = json.dumps(asdict(ctx))
+
+    async with _lock:
+        def _write() -> None:
+            conn = sqlite3.connect(STATE_DB)
+            try:
+                conn.execute(
+                    "INSERT OR REPLACE INTO state (user_id, ctx) VALUES (?, ?)",
+                    (user_id, ctx_json),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        await asyncio.to_thread(_write)
 
 
 async def clear_state(user_id: str) -> None:
-    pair = _STATE.pop(user_id, None)
-    if pair:
-        _, sess = pair
+    """Remove stored state and clear the associated session."""
+    await _ensure_table()
+
+    async with _lock:
+        def _delete() -> None:
+            conn = sqlite3.connect(STATE_DB)
+            try:
+                conn.execute("DELETE FROM state WHERE user_id = ?", (user_id,))
+                conn.commit()
+            finally:
+                conn.close()
+
+        await asyncio.to_thread(_delete)
+
+    # Clear conversation session (ignore failures)
+    try:
+        session = SQLiteSession(user_id, "noor_sessions.db")
         try:
-            await sess.clear_session()
-        except Exception:
-            pass
-        try:
-            await sess.close()
-        except Exception:
-            pass
+            await session.clear_session()
+        finally:
+            await session.close()
+    except Exception:
+        pass
+

--- a/src/app/whatsapp_webhook.py
+++ b/src/app/whatsapp_webhook.py
@@ -58,7 +58,7 @@ async def receive_wa(request: Request) -> Response:
         return Response(content='{"status":"ignored"}', media_type="application/json")
 
     # --- Load or create state (context + session) ---
-    state = get_state(sender_id)
+    state = await get_state(sender_id)
     if state:
         ctx, session = state
         is_new_session = False
@@ -133,7 +133,7 @@ async def receive_wa(request: Request) -> Response:
         reply = "عذرًا، في خلل تقني بسيط الآن. جرّب بعد قليل لو تكرّمت."
 
     # Persist state and send reply
-    touch_state(sender_id, ctx, session)
+    await touch_state(sender_id, ctx, session)
     fire_and_forget_send(sender_id, reply)
 
     # ---- idle summarization hooks ----


### PR DESCRIPTION
## Summary
- store session context in a SQLite-backed repository with async helpers for atomic access
- update WhatsApp webhook and idle watcher to use the new async state manager

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: async def functions are not natively supported, missing pytest-asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_689bd129e33c832d8d85f5f4e942a087