### PR TITLE
Secure WhatsApp webhook with token verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,11 @@ Customer-facing WhatsApp agent for Best Clinic 24, built with OpenAI Agents SDK.
 2) `pip install -r requirements.txt`
 3) Run API: `uvicorn src.app.main:app --reload`
 
+## Webhook security
+Incoming WhatsApp callbacks must include a secret token:
+
+1. Set `WA_WEBHOOK_TOKEN` in your environment.
+2. Configure your WhatsApp provider to send the header `X-WA-TOKEN` with this value.
+
+Requests missing or with an invalid token are logged and rejected with `401 Unauthorized`.
+

--- a/tests/test_webhook_auth.py
+++ b/tests/test_webhook_auth.py
@@ -1,0 +1,26 @@
+import importlib
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+
+@pytest.mark.asyncio
+async def test_webhook_requires_token(monkeypatch):
+    monkeypatch.setenv("WA_WEBHOOK_TOKEN", "expected")
+    from src.app import whatsapp_webhook
+    importlib.reload(whatsapp_webhook)
+
+    app = FastAPI()
+    app.include_router(whatsapp_webhook.router, prefix="/webhook")
+
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/webhook/wa", json={})
+        assert resp.status_code == 401
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/webhook/wa", headers={"X-WA-TOKEN": "wrong"}, json={}
+        )
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- require `X-WA-TOKEN` header matching `WA_WEBHOOK_TOKEN` before processing webhook calls
- document webhook authentication requirements
- test rejection of unauthorized webhook requests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bd826bf68832d81831219d721d305