### PR TITLE
Sanitize and validate phone numbers

### DIFF
--- a/src/app/parse_phone_number.py
+++ b/src/app/parse_phone_number.py
@@ -1,9 +1,26 @@
-def parse_whatsapp_to_local_palestinian_number(chat_id: str) -> str:
+import re
+from typing import Optional
+
+
+def parse_whatsapp_to_local_palestinian_number(chat_id: str) -> Optional[str]:
     """
     Turn a WhatsApp chatId like '97259XXXXXXX@c.us' into '059XXXXXXX'.
-    Keeps other formats best‑effort.
+    Non-digit characters are stripped before validation.
+    Returns the sanitized number in local format or ``None`` if invalid.
+
+    Raises:
+        ValueError: If ``chat_id`` is not a string.
     """
+    if not isinstance(chat_id, str):
+        raise ValueError("chat_id must be a string")
+
     raw = chat_id.split("@", 1)[0]
-    if raw.startswith("972"):
-        return "0" + raw[3:]
-    return raw
+    digits = re.sub(r"\D", "", raw)
+
+    if digits.startswith("972"):
+        digits = "0" + digits[3:]
+
+    if re.fullmatch(r"05\d{8}", digits):
+        return digits
+
+    return None

--- a/tests/test_parse_phone_number.py
+++ b/tests/test_parse_phone_number.py
@@ -1,0 +1,28 @@
+import pytest
+
+from src.app.parse_phone_number import parse_whatsapp_to_local_palestinian_number
+
+
+def test_parse_valid_numbers():
+    assert (
+        parse_whatsapp_to_local_palestinian_number("972591234567@c.us")
+        == "0591234567"
+    )
+    assert (
+        parse_whatsapp_to_local_palestinian_number("0591234567@c.us")
+        == "0591234567"
+    )
+    assert (
+        parse_whatsapp_to_local_palestinian_number("972-59 123 4567@c.us")
+        == "0591234567"
+    )
+
+
+def test_parse_invalid_numbers():
+    assert parse_whatsapp_to_local_palestinian_number("12345@c.us") is None
+    assert parse_whatsapp_to_local_palestinian_number("hello") is None
+
+
+def test_parse_raises_on_non_string():
+    with pytest.raises(ValueError):
+        parse_whatsapp_to_local_palestinian_number(None)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- Strip non-digit characters from WhatsApp chat IDs and convert to local format
- Validate local numbers match `05XXXXXXXX`, returning `None` when invalid
- Add tests covering valid, invalid, and malformed inputs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bdc37f858832d99e691e0e1ac8ecb