### PR TITLE
Prevent token leakage in Noor responses

### DIFF
--- a/src/app/output_sanitizer.py
+++ b/src/app/output_sanitizer.py
@@ -1,0 +1,22 @@
+import re
+from typing import Pattern, List
+
+TOKEN_PATTERNS: List[Pattern[str]] = [
+    re.compile(r"\bsvc\w+\b"),
+    re.compile(r"\bemp\w+\b"),
+    re.compile(r"\b[a-zA-Z0-9+/=_-]{20,}\b"),
+]
+
+
+def redact_tokens(text: str) -> str:
+    """Redact service/employee tokens from a string.
+
+    Any substrings that look like service or employee tokens are replaced
+    with ``[REDACTED]`` before the text is sent to users.
+    """
+    if not isinstance(text, str):
+        return text
+    redacted = text
+    for pattern in TOKEN_PATTERNS:
+        redacted = pattern.sub("[REDACTED]", redacted)
+    return redacted

--- a/src/my_agents/noor_agent.py
+++ b/src/my_agents/noor_agent.py
@@ -3,6 +3,7 @@ from src.my_agents.prompts.system_prompt_noor import SYSTEM_PROMPT
 from src.tools.kb_agent_tool import kb_tool_for_noor
 from src.tools.booking_agent_tool import booking_tool_for_noor
 from src.app.context_models import BookingContext
+from src.app.output_sanitizer import redact_tokens
 
 
 def _dynamic_footer(ctx: BookingContext) -> str:
@@ -49,4 +50,4 @@ async def run_noor_turn(
     result = await Runner.run(
         starting_agent=noor, input=user_input, session=session, context=ctx
     )
-    return result.final_output
+    return redact_tokens(result.final_output)

--- a/src/my_agents/prompts/system_prompt_noor.py
+++ b/src/my_agents/prompts/system_prompt_noor.py
@@ -25,6 +25,7 @@ You are **Noor (نور)**—a warm, confident assistant for **Best Clinic 24** (
 **Scope & boundaries**
 - Stay on Best Clinic 24 topics. If unrelated, decline briefly and steer back.
 - Never invent services, names, phones, or facts. If unsure, say you'll confirm or share main contact numbers.
+- Never expose service or employee tokens or any internal IDs.
 - No jokes/philosophy/world news/flirting. For abusive messages: set a firm, polite boundary and share the clinic phone; end politely if it continues.
 
 **Grounding & retrieval**

--- a/tests/test_output_sanitizer.py
+++ b/tests/test_output_sanitizer.py
@@ -1,0 +1,17 @@
+from src.app.output_sanitizer import redact_tokens
+
+
+def test_redact_tokens_replaces_known_patterns():
+    text = (
+        "Use svc123 and emp456 then token ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 for debugging"
+    )
+    result = redact_tokens(text)
+    assert "svc123" not in result
+    assert "emp456" not in result
+    assert "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" not in result
+    assert result.count("[REDACTED]") == 3
+
+
+def test_redact_tokens_without_patterns():
+    text = "Hello world"
+    assert redact_tokens(text) == text


### PR DESCRIPTION
## Summary
- forbid sharing service or employee tokens in Noor's system prompt
- sanitize agent replies by redacting service and employee tokens
- cover token redaction with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689be429a0cc832db0c97bb05cffaa7c