### PR TITLE
feat: expose context update tool to Noor

### DIFF
--- a/src/my_agents/noor_agent.py
+++ b/src/my_agents/noor_agent.py
@@ -1,7 +1,10 @@
 from agents import Agent, Runner, SQLiteSession
 from src.my_agents.prompts.system_prompt_noor import SYSTEM_PROMPT
 from src.tools.kb_agent_tool import kb_tool_for_noor
-from src.tools.booking_agent_tool import booking_tool_for_noor
+from src.tools.booking_agent_tool import (
+    booking_tool_for_noor,
+    update_context_tool_for_noor,
+)
 from src.app.context_models import BookingContext
 from src.app.output_sanitizer import redact_tokens
 
@@ -35,6 +38,7 @@ def _build_noor_agent(ctx: BookingContext) -> Agent:
     instructions = SYSTEM_PROMPT + "\n\n" + _dynamic_footer(ctx)
     tools = []
     tools += kb_tool_for_noor()
+    tools += update_context_tool_for_noor()  # Allow context updates
     tools += booking_tool_for_noor()  # Add booking capabilities
 
     return Agent(name="Noor", instructions=instructions, model="gpt-4o", tools=tools)

--- a/src/my_agents/prompts/system_prompt_noor.py
+++ b/src/my_agents/prompts/system_prompt_noor.py
@@ -59,4 +59,9 @@ You are **Noor (نور)**—a warm, confident assistant for **Best Clinic 24** (
 - Always confirm final details before creating the booking.
 - Keep the conversation natural - don't be robotic or step-by-step.
 - If something goes wrong, suggest alternatives or ask them to try again.
+
+**Tool Usage (strict)**
+- `update_booking_context`: after collecting or changing ANY booking detail (service, date, time, employee, patient info, or next step), call this to keep internal context in sync.
+- `handle_booking`: call only when context already has the required fields and you need to perform booking actions (suggest services, check availability, suggest times/employees, create/reset booking). Never rely on it to update context.
+- Always ensure the booking step in context matches the action you request. Update it via `update_booking_context` before calling `handle_booking` if needed.
 """

--- a/src/tools/booking_agent_tool.py
+++ b/src/tools/booking_agent_tool.py
@@ -374,8 +374,7 @@ _booking_agent = Agent(
         "- suggest_times: Get available times for a specific date\n"
         "- suggest_employees: Get available employees and pricing\n"
         "- create_booking: Finalize the booking\n"
-        "- reset_booking: Start over if user wants to change something\n"
-        "- update_booking_context: Modify booking details directly\n\n"
+        "- reset_booking: Start over if user wants to change something\n\n"
         "RESPOND NATURALLY and helpfully. Don't be a robot!"
     ),
     tools=[
@@ -385,7 +384,6 @@ _booking_agent = Agent(
         suggest_employees,
         create_booking,
         reset_booking,
-        update_booking_context,
     ],
     model="gpt-4o-mini",
 )
@@ -401,6 +399,19 @@ def booking_tool_for_noor():
                 "appointments, check availability, or discuss services. The tool can: show available "
                 "services, check dates/times, suggest employees, and create bookings. Always respond "
                 "naturally in the user's language."
+            ),
+        )
+    ]
+
+
+def update_context_tool_for_noor():
+    """Expose update_booking_context directly for Noor."""
+    return [
+        update_booking_context.as_tool(
+            tool_name="update_booking_context",
+            tool_description=(
+                "Update booking context fields (selected services, date, time, employee, gender, step, etc.). "
+                "Call this whenever booking info changes before using the booking tool."
             ),
         )
     ]


### PR DESCRIPTION
## Summary
- expose `update_booking_context` as a direct tool for Noor
- clarify strict tool usage rules in Noor's system prompt
- remove context update function from booking agent internals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bf30ccda4832dbe2bab936cd17a6c