### PR TITLE
Flatten tool list for Noor agent

### DIFF
--- a/src/my_agents/noor_agent.py
+++ b/src/my_agents/noor_agent.py
@@ -36,7 +36,11 @@ def _dynamic_footer(ctx: BookingContext) -> str:
 
 def _build_noor_agent(ctx: BookingContext) -> Agent:
     instructions = SYSTEM_PROMPT + "\n\n" + _dynamic_footer(ctx)
-    tools = [update_booking_context, kb_tool_for_noor(), booking_tool_for_noor()]
+    # kb_tool_for_noor() and booking_tool_for_noor() each return a list of tools.
+    # If we naively append them, Agent.tools would contain nested lists, which breaks
+    # the Runner (it expects each element to be a Tool with a ``name`` attribute).
+    # Flatten the lists so that ``Agent`` receives a simple list of Tool objects.
+    tools = [update_booking_context] + kb_tool_for_noor() + booking_tool_for_noor()
 
     return Agent(name="Noor", instructions=instructions, model="gpt-4o", tools=tools)
 

--- a/tests/test_noor_agent.py
+++ b/tests/test_noor_agent.py
@@ -1,0 +1,6 @@
+from src.my_agents.noor_agent import _build_noor_agent
+from src.app.context_models import BookingContext
+
+def test_noor_agent_tools_are_flat():
+    agent = _build_noor_agent(BookingContext())
+    assert all(not isinstance(t, list) for t in agent.tools)


### PR DESCRIPTION
## Summary
- fix nested tool list creation for Noor agent to avoid `list` attribute errors
- add unit test ensuring Noor agent tool list is flat

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bf9ef9ba0832db3a0747cd72acf61