### PR TITLE
refactor: expose booking tool functions

### DIFF
--- a/src/my_agents/noor_agent.py
+++ b/src/my_agents/noor_agent.py
@@ -2,7 +2,12 @@ from agents import Agent, Runner, SQLiteSession
 from src.my_agents.prompts.system_prompt_noor import SYSTEM_PROMPT
 from src.tools.kb_agent_tool import kb_tool_for_noor
 from src.tools.booking_agent_tool import (
-    booking_tool_for_noor,
+    suggest_services,
+    check_availability,
+    suggest_times,
+    suggest_employees,
+    create_booking,
+    reset_booking,
     update_booking_context,
 )
 from src.app.context_models import BookingContext
@@ -36,11 +41,19 @@ def _dynamic_footer(ctx: BookingContext) -> str:
 
 def _build_noor_agent(ctx: BookingContext) -> Agent:
     instructions = SYSTEM_PROMPT + "\n\n" + _dynamic_footer(ctx)
-    # kb_tool_for_noor() and booking_tool_for_noor() each return a list of tools.
-    # If we naively append them, Agent.tools would contain nested lists, which breaks
-    # the Runner (it expects each element to be a Tool with a ``name`` attribute).
-    # Flatten the lists so that ``Agent`` receives a simple list of Tool objects.
-    tools = [update_booking_context] + kb_tool_for_noor() + booking_tool_for_noor()
+    # kb_tool_for_noor() returns a list of tools. Combine it with the booking
+    # tool functions and ``update_booking_context`` so ``Agent`` receives a flat
+    # list of Tool objects.
+    tools = [
+        update_booking_context,
+        *kb_tool_for_noor(),
+        suggest_services,
+        check_availability,
+        suggest_times,
+        suggest_employees,
+        create_booking,
+        reset_booking,
+    ]
 
     return Agent(name="Noor", instructions=instructions, model="gpt-4o", tools=tools)
 

--- a/src/my_agents/prompts/system_prompt_noor.py
+++ b/src/my_agents/prompts/system_prompt_noor.py
@@ -62,6 +62,6 @@ You are **Noor (نور)**—a warm, confident assistant for **Best Clinic 24** (
 
 **Tool Usage (strict)**
 - `update_booking_context`: after collecting or changing ANY booking detail (service, date, time, employee, patient info, or next step), call this to keep internal context in sync.
-- `handle_booking`: call only when context already has the required fields and you need to perform booking actions (suggest services, check availability, suggest times/employees, create/reset booking). Never rely on it to update context.
-- Always ensure the booking step in context matches the action you request. Update it via `update_booking_context` before calling `handle_booking` if needed.
+- `suggest_services`, `check_availability`, `suggest_times`, `suggest_employees`, `create_booking`, `reset_booking`: call these only when context already has the required fields for the action. Never rely on them to update context.
+- Always ensure the booking step in context matches the action you request. Update it via `update_booking_context` before calling the booking tools if needed.
 """

--- a/src/tools/booking_agent_tool.py
+++ b/src/tools/booking_agent_tool.py
@@ -6,7 +6,7 @@ Uses the correct @function_tool pattern from Agents SDK.
 from typing import List, Dict, Optional
 import json
 from pydantic import BaseModel, ConfigDict
-from agents import Agent, function_tool, RunContextWrapper
+from agents import function_tool, RunContextWrapper
 
 from src.tools.booking_tool import booking_tool, BookingFlowError
 from src.data.services import get_services_by_gender
@@ -353,52 +353,12 @@ async def update_booking_context(
     return "تم تحديث الحقول: " + ", ".join(updates_dict.keys())
 
 
-# The mini-agent that owns the booking tools (Noor won't see the complex API calls directly)
-_booking_agent = Agent(
-    name="BookingAgent",
-    instructions=(
-        "You are a booking assistant for Best Clinic 24. Help users book appointments by "
-        "understanding their requests and using the tools.\n\n"
-        "RULES:\n"
-        "- Converse in the user's language (Arabic or English).\n"
-        "- When you call a tool, return its output verbatim, including IDs or tokens. Do not translate, "
-        "  summarize, or drop fields.\n"
-        "- Outside of raw tool output, stay warm, helpful, and conversational.\n"
-        "- When suggesting dates or times, offer 2-3 options if available; if only one exists, explain why.\n"
-        "- Confirm all booking details before creating a booking.\n"
-        "- Handle errors gracefully and suggest alternatives.\n"
-        "- Avoid commentary about APIs or tools—just show the raw output when relevant.\n\n"
-        "AVAILABLE TOOLS:\n"
-        "- suggest_services: Show available services for a gender\n"
-        "- check_availability: Check available dates for selected services\n"
-        "- suggest_times: Get available times for a specific date\n"
-        "- suggest_employees: Get available employees and pricing\n"
-        "- create_booking: Finalize the booking\n"
-        "- reset_booking: Start over if user wants to change something\n\n"
-        "RESPOND NATURALLY and helpfully. Don't be a robot!"
-    ),
-    tools=[
-        suggest_services,
-        check_availability,
-        suggest_times,
-        suggest_employees,
-        create_booking,
-        reset_booking,
-    ],
-    model="gpt-4o-mini",
-)
-
-
-def booking_tool_for_noor():
-    """Return the tool object to plug into Noor.tools."""
-    return [
-        _booking_agent.as_tool(
-            tool_name="handle_booking",
-            tool_description=(
-                "Handle appointment booking for Best Clinic 24. Use this when users want to book "
-                "appointments, check availability, or discuss services. The tool can: show available "
-                "services, check dates/times, suggest employees, and create bookings. Always respond "
-                "naturally in the user's language."
-            ),
-        )
-    ]
+__all__ = [
+    "suggest_services",
+    "check_availability",
+    "suggest_times",
+    "suggest_employees",
+    "create_booking",
+    "reset_booking",
+    "update_booking_context",
+]


### PR DESCRIPTION
## Summary
- drop BookingAgent wrapper and export booking tools directly
- import booking functions individually in Noor agent
- update system prompt to reference new booking tools

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c6283fbbc832d8e243cd8f25bc093