### PR TITLE
Compute next booking step in controller

### DIFF
--- a/src/tools/booking_agent_tool.py
+++ b/src/tools/booking_agent_tool.py
@@ -390,6 +390,11 @@ async def update_booking_context(
     if not updates_dict:
         return ToolResult(public_text="لم يتم تقديم أي تحديثات.", ctx_patch={})
 
+    if "next_booking_step" in updates_dict:
+        return ToolResult(
+            public_text="لا يمكن تعديل خطوة الحجز التالية مباشرة.", ctx_patch={}
+        )
+
     return ToolResult(
         public_text="تم تحديث الحقول: " + ", ".join(updates_dict.keys()),
         ctx_patch=updates_dict,

--- a/tests/test_step_controller.py
+++ b/tests/test_step_controller.py
@@ -1,0 +1,37 @@
+import json
+import pytest
+
+from src.app.context_models import BookingContext, BookingStep
+from src.tools.booking_agent_tool import update_booking_context, BookingContextUpdate
+from src.workflows.step_controller import StepController
+
+
+class DummyWrapper:
+    def __init__(self, ctx: BookingContext | None = None):
+        self.context = ctx or BookingContext()
+
+
+@pytest.mark.asyncio
+async def test_update_booking_context_rejects_next_step():
+    wrapper = DummyWrapper()
+    updates = BookingContextUpdate(next_booking_step=BookingStep.SELECT_DATE)
+    payload = json.dumps({"updates": updates.model_dump()})
+    result = await update_booking_context.on_invoke_tool(wrapper, payload)
+    assert result.ctx_patch == {}
+    assert "لا يمكن" in result.public_text
+
+
+def test_apply_patch_sets_next_step():
+    ctx = BookingContext()
+    controller = StepController(ctx)
+    controller.apply_patch({"selected_services_pm_si": ["svc1"], "next_booking_step": BookingStep.SELECT_EMPLOYEE})
+    assert ctx.next_booking_step == BookingStep.SELECT_DATE
+    controller.apply_patch({"appointment_date": "2024-06-01"})
+    assert ctx.next_booking_step == BookingStep.SELECT_TIME
+
+
+def test_apply_patch_rejects_downstream_fields():
+    ctx = BookingContext()
+    controller = StepController(ctx)
+    with pytest.raises(ValueError):
+        controller.apply_patch({"appointment_date": "2024-06-01"})


### PR DESCRIPTION
## Summary
- prevent manual `next_booking_step` updates in `update_booking_context`
- derive `next_booking_step` automatically and validate booking flow in `StepController`
- add tests for step transitions and validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c6847805c832dba52f30e051315b2