### PR TITLE
feat: allow reverting booking steps with invalidation notices

### DIFF
--- a/src/my_agents/noor_agent.py
+++ b/src/my_agents/noor_agent.py
@@ -8,6 +8,7 @@ from src.tools.booking_agent_tool import (
     suggest_employees,
     create_booking,
     reset_booking,
+    revert_to_step,
     update_booking_context,
 )
 from src.app.context_models import BookingContext
@@ -54,6 +55,7 @@ def _build_noor_agent(ctx: BookingContext) -> Agent:
         suggest_employees,
         create_booking,
         reset_booking,
+        revert_to_step,
     ]
 
     return Agent(name="Noor", instructions=instructions, model="gpt-4o", tools=tools)


### PR DESCRIPTION
## Summary
- add tool to revert to specific booking step and invalidate downstream data
- notify user when changing service, date, or time clears later selections
- expose revert tool and cover step reversion with tests

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c6ac7f990832d9f80f09bd30cf2ba