### PR TITLE
Add event logging for turn tracking

### DIFF
--- a/src/app/event_log.py
+++ b/src/app/event_log.py
@@ -1,0 +1,48 @@
+import json
+import os
+from pathlib import Path
+import contextvars
+from typing import Any, Dict
+
+# Path to the log file; can be overridden via EVENT_LOG_PATH env var or set_log_path.
+_LOG_PATH = Path(os.environ.get("EVENT_LOG_PATH", "noor_event_log.jsonl"))
+
+_current_turn_id: contextvars.ContextVar[int | None] = contextvars.ContextVar(
+    "current_turn_id", default=None
+)
+
+def set_log_path(path: str | Path) -> None:
+    """Override the log file path (useful for tests)."""
+    global _LOG_PATH
+    _LOG_PATH = Path(path)
+
+
+def get_log_path() -> Path:
+    """Return the current log file path."""
+    return _LOG_PATH
+
+
+def set_turn_id(turn_id: int) -> None:
+    """Set the active turn identifier for subsequent events."""
+    _current_turn_id.set(turn_id)
+
+
+def log_event(event: str, data: Dict[str, Any], *, turn_id: int | None = None) -> None:
+    """Append an event to the log as a JSON line.
+
+    Parameters
+    ----------
+    event:
+        Type of the event (e.g., "user_text", "tool_call").
+    data:
+        Arbitrary JSON-serializable payload.
+    turn_id:
+        Optional explicit turn identifier. If omitted, the previously set
+        turn id (via :func:`set_turn_id`) is used.
+    """
+    tid = turn_id if turn_id is not None else _current_turn_id.get()
+    record = {"turn_id": tid, "event": event, **data}
+    _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with _LOG_PATH.open("a", encoding="utf-8") as f:
+        json.dump(record, f, ensure_ascii=False)
+        f.write("\n")

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -1,0 +1,37 @@
+import json
+import pytest
+
+from src.app.event_log import set_log_path, set_turn_id, get_log_path
+from src.workflows.step_controller import StepControllerRunHooks
+from src.app.context_models import BookingContext
+from src.tools.tool_result import ToolResult
+
+
+class DummyWrapper:
+    def __init__(self):
+        self.context = BookingContext()
+
+
+class DummyTool:
+    name = "dummy_tool"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_and_step_transition_logged(tmp_path):
+    log_file = tmp_path / "events.jsonl"
+    set_log_path(log_file)
+    set_turn_id(1)
+
+    hooks = StepControllerRunHooks()
+    wrapper = DummyWrapper()
+    tool = DummyTool()
+    result = ToolResult(public_text="ok", ctx_patch={"selected_services_pm_si": ["svc1"]})
+
+    await hooks.on_tool_end(wrapper, None, tool, result)
+
+    with open(get_log_path(), "r", encoding="utf-8") as f:
+        events = [json.loads(line) for line in f if line.strip()]
+
+    assert any(e["event"] == "tool_call" for e in events)
+    assert any(e["event"] == "step_transition" for e in events)
+    assert all(e["turn_id"] == 1 for e in events)


### PR DESCRIPTION
## Summary
- add JSONL-based event logger for turn tracking
- log user text and intents in `run_noor_turn`
- capture tool calls and step transitions inside `StepController`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c6cf8fc68832d83433b72e5b47a11