### PR TITLE
Log diagnostics for failed WhatsApp sends

### DIFF
--- a/src/app/whatsapp_webhook.py
+++ b/src/app/whatsapp_webhook.py
@@ -62,11 +62,14 @@ async def _send_whatsapp(chat_id: str, text: str) -> None:
                     if 200 <= resp.status_code < 300:
                         success = True
                         break
-                    # Non-2xx response: log body and status
+                    # Non-2xx response: log body, status, and diagnostics
                     logger.error(
-                        "WhatsApp send failed: status=%s body=%s",
+                        "WhatsApp send failed: status=%s body=%s payload_len=%d req_headers=%s resp_headers=%s",
                         resp.status_code,
                         resp.text,
+                        len(chunk),
+                        resp.request.headers,
+                        resp.headers,
                     )
                     if resp.status_code in {429} or resp.status_code >= 500:
                         if attempt < retries:


### PR DESCRIPTION
## Summary
- extend error logging on Green-API failures with payload size and request/response headers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c7a1c5240832db1a3443bd08a52fe