### PR TITLE
feat: track available times and employees in booking context

### DIFF
--- a/src/app/context_models.py
+++ b/src/app/context_models.py
@@ -46,12 +46,15 @@ class BookingContext:
     # appointment details
     appointment_date: Optional[str] = None  # YYYY-MM-DD format
     appointment_time: Optional[str] = None  # HH:MM format
+    available_times: Optional[List[Dict]] = None  # available time slots
     employee_pm_si: Optional[str] = None  # selected employee token
     employee_name: Optional[str] = None  # human-readable employee name
+    offered_employees: Optional[List[Dict]] = None  # employees offered to user
 
     # pricing
     total_price: Optional[float] = None
     price_currency: str = "NIS"
+    checkout_summary: Optional[Dict] = None  # summary of booking details
 
     # booking status
     booking_confirmed: bool = False


### PR DESCRIPTION
## Summary
- extend booking context model with available times and offered employees
- add checkout summary field for pricing overview

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c82af16a0832db37c451ed53a62b4