### PR TITLE
Ensure appointment time aligns with available slots

### DIFF
--- a/tests/test_step_controller.py
+++ b/tests/test_step_controller.py
@@ -32,7 +32,12 @@ def test_apply_patch_sets_next_step():
     controller = StepController(ctx)
     controller.apply_patch({"selected_services_pm_si": ["svc1"], "next_booking_step": BookingStep.SELECT_EMPLOYEE})
     assert ctx.next_booking_step == BookingStep.SELECT_DATE
-    controller.apply_patch({"appointment_date": "2024-06-01"})
+    controller.apply_patch(
+        {
+            "appointment_date": "2024-06-01",
+            "available_times": [{"time": "09:00"}],
+        }
+    )
     assert ctx.next_booking_step == BookingStep.SELECT_TIME
 
 


### PR DESCRIPTION
## Summary
- Track `available_times`, `offered_employees`, and `checkout_summary` in step controller mappings
- Clear those fields when upstream selections change
- Require available times to be loaded and appointment time to be valid before advancing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c836a2694832da86a644d94b62d20