### PR TITLE
Refactor availability check and remove redundant time tool

### DIFF
--- a/src/my_agents/noor_agent.py
+++ b/src/my_agents/noor_agent.py
@@ -4,7 +4,6 @@ from src.tools.kb_agent_tool import kb_tool_for_noor
 from src.tools.booking_agent_tool import (
     suggest_services,
     check_availability,
-    suggest_times,
     suggest_employees,
     create_booking,
     reset_booking,
@@ -52,7 +51,6 @@ def _build_noor_agent(ctx: BookingContext) -> Agent:
         *kb_tool_for_noor(),
         suggest_services,
         check_availability,
-        suggest_times,
         suggest_employees,
         create_booking,
         reset_booking,

--- a/src/my_agents/prompts/system_prompt_noor.py
+++ b/src/my_agents/prompts/system_prompt_noor.py
@@ -62,6 +62,6 @@ You are **Noor (نور)**—a warm, confident assistant for **Best Clinic 24** (
 
 **Tool Usage (strict)**
 - `update_booking_context`: after collecting or changing ANY booking detail (service, date, time, employee, patient info, or next step), call this to keep internal context in sync.
-- `suggest_services`, `check_availability`, `suggest_times`, `suggest_employees`, `create_booking`, `reset_booking`: call these only when context already has the required fields for the action. Never rely on them to update context.
+- `suggest_services`, `check_availability`, `suggest_employees`, `create_booking`, `reset_booking`: call these only when context already has the required fields for the action. Never rely on them to update context.
 - Always ensure the booking step in context matches the action you request. Update it via `update_booking_context` before calling the booking tools if needed.
 """


### PR DESCRIPTION
## Summary
- Fetch available times directly via `check_availability` and patch context with slots
- Remove deprecated `suggest_times` tool and references
- Update system prompt and agent tool list accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c85751cbc832d911bf7b8a67637ed