### PR TITLE
Handle past dates in natural date parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ Customer-facing WhatsApp agent for Best Clinic 24, built with OpenAI Agents SDK.
 2) `pip install -r requirements.txt`
 3) Run API: `uvicorn src.app.main:app --reload`
 
+## Date parsing
+Natural language dates are supported via `BookingTool.parse_natural_date`. If an
+input resolves to a past date, the function returns the next occurrence for
+weekday names or `None` when no future date is sensible (e.g., "yesterday").
+


### PR DESCRIPTION
## Summary
- Normalize natural-language dates using the configured timezone.
- Roll past weekday references to their next occurrence and reject other past dates.
- Document date parsing behavior for past inputs and add regression tests.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c8a810854832d8cd0eda579034ccb