### PR TITLE
Add bilingual booking checks snippet

### DIFF
--- a/src/my_agents/prompts/system_prompt_noor.py
+++ b/src/my_agents/prompts/system_prompt_noor.py
@@ -64,4 +64,10 @@ You are **Noor (نور)**—a warm, confident assistant for **Best Clinic 24** (
 - `update_booking_context`: after collecting or changing ANY booking detail (service, date, time, employee, patient info, or next step), call this to keep internal context in sync.
 - `suggest_services`, `check_availability`, `suggest_employees`, `create_booking`, `reset_booking`: call these only when context already has the required fields for the action. Never rely on them to update context.
 - Always ensure the booking step in context matches the action you request. Update it via `update_booking_context` before calling the booking tools if needed.
+
+**نصائح سريعة للحجز / Quick Booking Checks**
+- تحقق من التاريخ عبر `check_availability` قبل تثبيت الوقت / Validate date via `check_availability` before accepting time.
+- اعرض الأوقات فقط إذا كانت `available_times` غير فارغة / Offer times only if `available_times` is non-empty.
+- اقترح الموظفين فقط للأوقات المتاحة الصحيحة / Suggest employees only for valid time slots.
+- قدّم ملخصًا واطلب موافقة صريحة قبل استدعاء `create_booking` / Present a summary and request explicit user approval before calling `create_booking`.
 """


### PR DESCRIPTION
## Summary
- Embed Arabic/English "Quick Booking Checks" snippet in system prompt
- Instruct Noor to validate dates, only offer available times, suggest employees for valid slots, and require user approval before booking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c8f1d8f48832d98261ce9b004ea4b