### PR TITLE
feat: clarify context invalidation messages

### DIFF
--- a/src/tools/booking_agent_tool.py
+++ b/src/tools/booking_agent_tool.py
@@ -494,9 +494,17 @@ async def update_booking_context(
     controller = StepController(ctx)
     start_version = ctx.version
     msg_map = {
-        BookingStep.SELECT_SERVICE: "تم تحديث الخدمات. يرجى اختيار التاريخ، الوقت، والطبيب من جديد.",
-        BookingStep.SELECT_DATE: "تم تحديث التاريخ. يرجى اختيار الوقت والطبيب من جديد.",
-        BookingStep.SELECT_TIME: "تم تحديث الوقت. يرجى اختيار الطبيب من جديد.",
+        BookingStep.SELECT_SERVICE: (
+            "تم تحديث الخدمات. تم مسح الأوقات المتاحة، الأطباء المقترحين، وملخص الحجز. "
+            "يرجى اختيار التاريخ، الوقت، والطبيب من جديد."
+        ),
+        BookingStep.SELECT_DATE: (
+            "تم تحديث التاريخ. تم مسح الأوقات المتاحة، الأطباء المقترحين، وملخص الحجز. "
+            "يرجى اختيار الوقت والطبيب من جديد."
+        ),
+        BookingStep.SELECT_TIME: (
+            "تم تحديث الوقت. تم مسح الأطباء المقترحين وملخص الحجز. يرجى اختيار الطبيب من جديد."
+        ),
     }
     for field in ["selected_services_pm_si", "appointment_date", "appointment_time"]:
         if field in updates_dict and getattr(ctx, field) != updates_dict[field]:

--- a/tests/test_step_controller.py
+++ b/tests/test_step_controller.py
@@ -81,6 +81,12 @@ async def test_update_booking_context_invalidates_downstream():
     payload = json.dumps({"updates": updates.model_dump()})
     result = await update_booking_context.on_invoke_tool(wrapper, payload)
     StepController(ctx).apply_patch(result.ctx_patch)
+    assert ctx.available_times is None
     assert ctx.appointment_time is None
     assert ctx.employee_pm_si is None
+    assert ctx.offered_employees is None
+    assert ctx.checkout_summary is None
+    assert "الأوقات المتاحة" in result.public_text
+    assert "الأطباء المقترحين" in result.public_text
+    assert "ملخص الحجز" in result.public_text
     assert "اختيار الوقت والطبيب" in result.public_text


### PR DESCRIPTION
## Summary
- clarify downstream reset messaging when services, date, or time change
- test context update clears available times, offered employees and checkout summary

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c8fe3f4ec832db2a9895c575d9512