### PR TITLE
Use Asia/Hebron timezone

### DIFF
--- a/src/app/context_models.py
+++ b/src/app/context_models.py
@@ -28,7 +28,7 @@ class BookingContext:
     user_name: Optional[str] = None
     user_phone: Optional[str] = None
     user_lang: Optional[str] = None
-    tz: str = "Asia/Jerusalem"
+    tz: str = "Asia/Hebron"
 
     # gender and section (determines available services)
     gender: Optional[str] = None  # 'male'/'female' or 'ذكر'/'أنثى'

--- a/src/app/session_memory.py
+++ b/src/app/session_memory.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 from openai import AsyncOpenAI
 from agents import Agent, Runner, SQLiteSession, ItemHelpers, RunConfig
 
-TZ_NAME = "Asia/Jerusalem"
+TZ_NAME = "Asia/Hebron"
 tz = pytz.timezone(TZ_NAME)
 
 


### PR DESCRIPTION
## Summary
- Default to Asia/Hebron timezone in booking context
- Align session memory timezone configuration with Asia/Hebron

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ca188bed4832d8785844819c048df