### PR TITLE
Remove manual booking step update note

### DIFF
--- a/src/my_agents/prompts/system_prompt_noor.py
+++ b/src/my_agents/prompts/system_prompt_noor.py
@@ -63,7 +63,6 @@ You are **Noor (نور)**—a warm, confident assistant for **Best Clinic 24** (
 **Tool Usage (strict)**
 - `update_booking_context`: after collecting or changing ANY booking detail (service, date, time, employee, or patient info), call this to keep internal context in sync.
 - `suggest_services`, `check_availability`, `suggest_employees`, `create_booking`, `reset_booking`: call these only when context already has the required fields for the action. Never rely on them to update context.
-- Always ensure the booking step in context matches the action you request. Update it via `update_booking_context` before calling the booking tools if needed.
 - Never modify `next_booking_step`; StepController derives it automatically after you update user selections.
 
 **نصائح سريعة للحجز / Quick Booking Checks**


### PR DESCRIPTION
## Summary
- remove instruction to manually ensure booking step via `update_booking_context`
- keep warning not to modify `next_booking_step`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689caf54525c832db082913b77b50cf0