### PR TITLE
Remove next step hint from availability patch

### DIFF
--- a/src/tools/booking_agent_tool.py
+++ b/src/tools/booking_agent_tool.py
@@ -136,7 +136,6 @@ async def check_availability(
         patch = {
             "appointment_date": date,
             "available_times": slots,
-            "next_booking_step": BOOKING_STEP_TRANSITIONS[BookingStep.SELECT_DATE][0],
         }
 
         return ToolResult(public_text=text, ctx_patch=patch, private_data=slots, version=ctx.version)

--- a/tests/test_step_controller.py
+++ b/tests/test_step_controller.py
@@ -138,6 +138,7 @@ async def test_check_availability_stores_available_times(monkeypatch):
 
     payload = json.dumps({"date": "2024-06-01"})
     result = await check_availability.on_invoke_tool(wrapper, payload)
+    assert "next_booking_step" not in result.ctx_patch
     StepController(ctx).apply_patch(result.ctx_patch)
     assert ctx.available_times == slots
     assert ctx.next_booking_step == BookingStep.SELECT_TIME


### PR DESCRIPTION
## Summary
- stop `check_availability` from returning `next_booking_step`
- confirm `StepController` derives the next step on its own
- adjust step controller tests for the removed field

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cb0589ca0832da52f5d990d4aa380