### PR TITLE
Polish booking flow state and prompts

### DIFF
--- a/src/app/memory_prefetch.py
+++ b/src/app/memory_prefetch.py
@@ -25,7 +25,7 @@ _prefetch_agent = Agent(
         "Filter: type=noor_chat_summary AND user_id=<given> (and user_phone if provided).\n"
         "Sort by end_time_iso DESC and return up to N items.\n"
         "OUTPUT CONTRACT (strict):\n"
-        "- Return ONLY the Key points, Next best action, and Reacp from the body text (not the YAML front matter) of each summary as it is, in order.\n"
+        "- Return ONLY the Key points, Next best action, and Recap from the body text (not the YAML front matter) of each summary as it is, in order.\n"
         "- Separate summaries content by a single line containing exactly: ---\n"
         "- If no results, return an empty string.\n"
         "- Do NOT add any commentary, headers, or tool and files mentions."

--- a/src/app/whatsapp_webhook.py
+++ b/src/app/whatsapp_webhook.py
@@ -177,13 +177,16 @@ async def receive_wa(request: Request) -> Response:
             ctx=ctx,
             session=session,
         )
-    except Exception as e:
-        print(e)
+    except Exception:
+        logger.exception("run_noor_turn failed")
         reply = "عذرًا، في خلل تقني بسيط الآن. جرّب بعد قليل لو تكرّمت."
 
-    # Persist state and send reply
-    await touch_state(sender_id, ctx, session)
+    # Send reply even if persistence fails
     fire_and_forget_send(sender_id, reply)
+    try:
+        await touch_state(sender_id, ctx, session)
+    except Exception:
+        logger.exception("touch_state failed for %s", sender_id)
 
     # ---- idle summarization hooks ----
     await update_last_seen(sender_id)

--- a/src/my_agents/noor_agent.py
+++ b/src/my_agents/noor_agent.py
@@ -20,7 +20,7 @@ def _dynamic_footer(ctx: BookingContext) -> str:
     lines = []
     if ctx and (ctx.user_name or ctx.user_phone):
         lines += [
-            "### THIS SECTION IS THE RESULT OF DYNAMIC INJECTION OF INTERNAL CONTEXT (do not reveal to user use the info natuarally)"
+            "### THIS SECTION IS THE RESULT OF DYNAMIC INJECTION OF INTERNAL CONTEXT (do not reveal to user; use the info naturally)"
         ]
         if ctx.user_name:
             lines.append(f"user_name={ctx.user_name}")

--- a/src/tools/kb_agent_tool.py
+++ b/src/tools/kb_agent_tool.py
@@ -39,11 +39,11 @@ def _scrub_files_phrasing(text: str) -> str:
 _kb_agent = Agent(
     name="ClinicKBAgent",
     instructions=(
-        "You MUST call FileSearch tool and retrieve official clinic or medical facts"
+        "You MUST call the FileSearch tool and retrieve official clinic or medical facts "
         "(address/phones/services/doctors/prices/hours/policies/conditions/treatments) as per input query. "
         "Answer concisely in the user's language as short bullet points (no more than 10 points). "
         "Present answers plainly. **Never mention tools, search, “files,” “documents,” “uploads,” or “vector stores.”**"
-        "If a fact isn't available, don't guess—offer to confirm or appologize."
+        "If a fact isn't available, don't guess—offer to confirm or apologize."
     ),
     tools=[t for t in [_build_filesearch()] if t],
     model="gpt-4o-mini",

--- a/src/workflows/step_controller.py
+++ b/src/workflows/step_controller.py
@@ -140,7 +140,7 @@ class StepController:
             return BookingStep.SELECT_SERVICE
         if not self.ctx.appointment_date:
             return BookingStep.SELECT_DATE
-        if not self.ctx.available_times:
+        if not self.ctx.available_times and not self.ctx.appointment_time:
             return BookingStep.SELECT_DATE
         if not self.ctx.appointment_time:
             return BookingStep.SELECT_TIME

--- a/tests/test_step_controller.py
+++ b/tests/test_step_controller.py
@@ -196,7 +196,8 @@ async def test_suggest_employees_respects_available_times_and_populates(monkeypa
 
     payload = json.dumps({"time": "09:00"})
     result = await suggest_employees.on_invoke_tool(wrapper, payload)
-    assert result.ctx_patch["appointment_time"] == "09:00"
-    assert result.ctx_patch["offered_employees"] == employees
-    assert result.ctx_patch["checkout_summary"] == summary
-    assert result.ctx_patch["next_booking_step"] == BookingStep.SELECT_EMPLOYEE
+    StepController(ctx).apply_patch(result.ctx_patch)
+    assert ctx.appointment_time == "09:00"
+    assert ctx.offered_employees == employees
+    assert ctx.checkout_summary == summary
+    assert ctx.next_booking_step == BookingStep.SELECT_EMPLOYEE


### PR DESCRIPTION
## Summary
- Persist BookingStep enums as strings for reliable reloads
- Improve booking tools: human-friendly service list, clear stale times, stable idempotency key
- Polish prompts, docs and webhook handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cb5c70110832db4379a890bacadf3