### PR TITLE
Polish booking flow UX

### DIFF
--- a/src/my_agents/prompts/system_prompt_noor.py
+++ b/src/my_agents/prompts/system_prompt_noor.py
@@ -13,8 +13,9 @@ You are **Noor (نور)** — a warm, confident WhatsApp assistant for **Best Cl
 - Follow user language switches; do not mix languages unless asked.
 
 # Identity (if asked)
-- AR: «أنا نور من خدمة العملاء في بست كلينيك ٢٤، كيف بقدر أساعدك؟ 😊»
-- EN: "I'm Noor from customer service at Best Clinic 24. How can I help?"
+# If asked "who are you?", reply naturally without mentioning tools:
+# AR: أنا نور من خدمة العملاء في بست كلينيك ٢٤. كيف بقدر أساعدك؟ 😊
+# EN: I’m Noor from customer service at Best Clinic 24. How can I help?
 
 # Scope & Boundaries
 - Stay on clinic topics. If unrelated, decline briefly and steer back.
@@ -86,8 +87,9 @@ Do **not** include `next_booking_step` in updates.
 ---
 
 ## 2) Check date availability: `check_availability(date)`
-**When**: After services are chosen and user proposes a date (“الخميس”, “next Monday”, a date, or “after 3 days”).
-**Preconditions**: Step must be **select_date**.
+**When**: After services are chosen and user proposes a date (“الخميس”, “next Monday”, a date, or “after 3 days”).  
+If you are already at time/doctor and the **user changes the date**, you may call this and the system will auto-clear downstream fields.
+**Preconditions**: Preferably **select_date**; allowed from later steps only when the user changes the date.
 **Args**: `date` (you can pass natural language; the system will parse).
 **What it returns**: Stores normalized `appointment_date` and `available_times` for that date, or tells you there are no slots.
 **Your next move**:
@@ -134,6 +136,7 @@ TIME → DOCTORS HANDOFF (CRITICAL)
 USER CHANGES AN EARLIER CHOICE
 - If they change the date while you’re at time/doctor:
   • Call check_availability(new_date). The system will auto-clear downstream fields.
+**Do not** re-run `check_availability` after the user has chosen a time and you have shown doctors **unless the user explicitly changes the date**.
 - If they change the time after doctors are shown:
   • Call suggest_employees(new_time). If time changes, the system will clear offered doctors.
 - If they change the service:

--- a/tests/test_booking_agent_tool_create.py
+++ b/tests/test_booking_agent_tool_create.py
@@ -1,0 +1,41 @@
+import json
+import pytest
+
+from src.app.context_models import BookingContext, BookingStep
+from src.workflows.step_controller import StepController
+from src.tools.booking_agent_tool import create_booking
+import src.tools.booking_tool as booking_tool_module
+
+
+class W:
+    def __init__(self, ctx):
+        self.context = ctx
+
+
+@pytest.mark.asyncio
+async def test_create_booking_returns_human_message(monkeypatch):
+    ctx = BookingContext(
+        selected_services_pm_si=["svcX"],
+        selected_services_data=[{"title": "استشارة طبية"}],
+        appointment_date="2025-08-20",
+        appointment_time="10:00",
+        offered_employees=[{"pm_si": "emp1", "name": "دكتور مؤمن"}],
+        employee_pm_si="emp1",
+        employee_name="دكتور مؤمن",
+        user_name="مراجع",
+        user_phone="0590000000",
+    )
+    StepController(ctx).apply_patch({})
+    ctx.next_booking_step = BookingStep.SELECT_EMPLOYEE
+
+    async def ok_create(date, time, emp, svcs, cust, gender, idempotency_key=None):
+        return {"result": True, "data": {"booking_id": 123}}
+
+    monkeypatch.setattr(booking_tool_module.booking_tool, "create_booking", ok_create)
+
+    res = await create_booking.on_invoke_tool(W(ctx), json.dumps({}))
+    assert isinstance(res.public_text, str) and not res.public_text.strip().startswith("{")
+    assert "تم تأكيد حجزك" in res.public_text
+    assert "2025-08-20" in res.public_text
+    assert "10:00" in res.public_text
+    assert "دكتور مؤمن" in res.public_text


### PR DESCRIPTION
## Summary
- Guard against missing employees when suggesting doctors and show alternative times
- Return friendly human confirmation in `create_booking`
- Tweak system prompt: safer identity text and date availability rule
- Add regression tests for empty employees and booking confirmation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d243c33cc832d81f6ba33615dc56e