### PR TITLE
Handle single-doctor confirmations and relax doctor selection preconditions

### DIFF
--- a/src/my_agents/prompts/system_prompt_noor.py
+++ b/src/my_agents/prompts/system_prompt_noor.py
@@ -133,6 +133,11 @@ TIME → DOCTORS HANDOFF (CRITICAL)
 - If you already set the time and you need to re-fetch doctors for the SAME time,
   you may call suggest_employees(time) again.
 
+إذا عرضتُ طبيباً واحداً فقط لوقت معيّن وقال المستخدم "نعم" أو "أكّد":
+- اعتبر ذلك موافقة على اختيار هذا الطبيب.
+- نفّذ داخلياً: update_booking_context(employee_name=<الاسم الظاهر>) ثم create_booking().
+- إذا فشل التحديث لأي سبب، أعد استدعاء suggest_employees(الوقت نفسه) ثم اطلب اختيار الطبيب بالاسم.
+
 USER CHANGES AN EARLIER CHOICE
 - If they change the date while you’re at time/doctor:
   • Call check_availability(new_date). The system will auto-clear downstream fields.


### PR DESCRIPTION
## Summary
- Auto-select a doctor when only one option is offered during booking confirmation
- Allow storing `employee_name` after time selection without requiring available times, mapping strictly from `offered_employees`
- Teach model to immediately confirm booking when user says yes after a single-doctor list
- Add regression tests for the new auto-select and employee-name prerequisites

## Testing
- `pytest tests/test_booking_flow_regressions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d282bc368832d8ad571d2a378731a