### PR TITLE
Handle mid-flow service list requests

### DIFF
--- a/src/my_agents/prompts/system_prompt_noor.py
+++ b/src/my_agents/prompts/system_prompt_noor.py
@@ -83,6 +83,7 @@ Do **not** include `next_booking_step` in updates.
 **Your next move**: Ask the user which service they want, then call `update_booking_context` with their choice(s).
 
 *Gender note*: If not obvious, politely ask “رجاء اختر القسم (رجال/نساء)؟” or “Which section do you prefer (men/women)?” and set via `update_booking_context(gender=...)`. Defaulting is allowed but confirming is better.
+- If the user asks for the services list mid-flow (date/time/doctor), show the list without changing the current step. Ask: "هل تريد تغيير الخدمة؟" If yes → `revert_to_step("select_service")` then `update_booking_context(selected_services_pm_si=[...])` and continue.
 
 ---
 

--- a/tests/test_suggest_services.py
+++ b/tests/test_suggest_services.py
@@ -1,0 +1,28 @@
+import json
+import pytest
+
+from src.app.context_models import BookingContext, BookingStep
+from src.tools.booking_agent_tool import suggest_services
+from src.workflows.step_controller import StepController
+
+
+class Wrapper:
+    def __init__(self, ctx):
+        self.context = ctx
+
+
+@pytest.mark.asyncio
+async def test_suggest_services_patches_only_at_service_step():
+    ctx = BookingContext(gender="male")
+    res = await suggest_services.on_invoke_tool(Wrapper(ctx), json.dumps({}))
+    assert res.ctx_patch and "selected_services_data" in res.ctx_patch
+
+    StepController(ctx).apply_patch({"selected_services_pm_si": ["x"]})
+    StepController(ctx).apply_patch(
+        {"appointment_date": "2025-08-21", "available_times": [{"time": "09:00"}]}
+    )
+    assert ctx.next_booking_step == BookingStep.SELECT_TIME
+
+    res2 = await suggest_services.on_invoke_tool(Wrapper(ctx), json.dumps({}))
+    assert res2.ctx_patch == {}
+    assert "هذه قائمة بالخدمات المتاحة" in res2.public_text


### PR DESCRIPTION
## Summary
- Allow suggest_services to show services anytime and only patch context before service selection, adding a note to revert if change requested
- Clarify system prompt for mid-flow service list requests
- Add unit test ensuring suggest_services only patches at service step

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d30fd153c832d83fcf1d5aaebf066