### PR TITLE
Harden booking state and WhatsApp intake

### DIFF
--- a/src/app/context_models.py
+++ b/src/app/context_models.py
@@ -1,8 +1,12 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional
 from datetime import datetime
 from zoneinfo import ZoneInfo
+
+
+def _now_iso() -> str:
+    return datetime.now(ZoneInfo("Asia/Hebron")).strftime("%Y-%m-%dT%H:%M:%S.%f%z")
 
 
 class BookingStep(str, Enum):
@@ -33,9 +37,7 @@ class BookingContext:
     user_phone: Optional[str] = None
     user_lang: Optional[str] = None
     tz: str = "Asia/Hebron"
-    current_datetime: Optional[str] = datetime.now(ZoneInfo("Asia/Hebron")).strftime(
-        "%Y-%m-%dT%H:%M:%S%z"
-    )  # ISO format
+    current_datetime: Optional[str] = field(default_factory=_now_iso)
 
     # gender and section (determines available services)
     gender: Optional[str] = None  # 'male'/'female' or 'ذكر'/'أنثى'

--- a/src/app/http_client.py
+++ b/src/app/http_client.py
@@ -1,0 +1,3 @@
+import httpx
+
+client = httpx.AsyncClient(timeout=httpx.Timeout(10.0, connect=5.0, read=10.0, write=10.0))

--- a/src/app/utils_text.py
+++ b/src/app/utils_text.py
@@ -1,0 +1,59 @@
+from typing import Any, Tuple, List
+
+MAX_WA_BYTES = 3500  # adjust to your sender’s hard limit headroom
+
+def extract_text_from_wa(body: dict) -> Tuple[str, bool]:
+    """
+    Returns (text, had_attachments). Supports textMessageData, extendedTextMessageData,
+    and flags when message is non-text (images/docs).
+    """
+    try:
+        msg = body.get("messageData") or {}
+        txt = (msg.get("textMessageData") or {}).get("textMessage")
+        if not txt:
+            txt = (msg.get("extendedTextMessageData") or {}).get("text")
+        if isinstance(txt, str) and txt.strip():
+            return txt.strip(), False
+        # Non-text?
+        if msg.get("fileMessageData") or msg.get("imageMessageData") or msg.get("videoMessageData"):
+            return "", True
+    except Exception:
+        pass
+    return "", False
+
+def split_for_whatsapp_by_bytes(text: str, max_bytes: int = MAX_WA_BYTES) -> List[str]:
+    """
+    Splits on UTF-8 byte boundaries, not char count — avoids breaking emoji/diacritics.
+    Prefers splitting on whitespace; falls back to hard byte cut.
+    """
+    chunks, buf = [], ""
+    for token in text.split(" "):
+        tentative = (buf + (" " if buf else "") + token) if token else buf
+        if len(tentative.encode("utf-8")) <= max_bytes:
+            buf = tentative
+            continue
+        if buf:
+            chunks.append(buf)
+            buf = token
+            if buf:
+                buf = " " + buf
+        else:
+            # single token too large; hard split
+            b = token.encode("utf-8")
+            start = 0
+            while start < len(b):
+                end = min(start + max_bytes, len(b))
+                # safe decode slice
+                piece = b[start:end]
+                while True:
+                    try:
+                        chunks.append(piece.decode("utf-8"))
+                        break
+                    except UnicodeDecodeError:
+                        end -= 1
+                        piece = b[start:end]
+                start = end
+            buf = ""
+    if buf:
+        chunks.append(buf)
+    return chunks

--- a/src/workflows/step_controller.py
+++ b/src/workflows/step_controller.py
@@ -160,6 +160,8 @@ class StepController:
             step = self._FIELD_TO_STEP.get(name)
             if step is None:
                 continue
+            if value is None or value is False:
+                continue
             for req in self._STEP_PREREQS.get(step, []):
                 if not combined.get(req):
                     raise ValueError(

--- a/tests/test_context_now.py
+++ b/tests/test_context_now.py
@@ -1,0 +1,6 @@
+from src.app.context_models import BookingContext
+
+def test_now_factory_changes_between_instances():
+    a = BookingContext().current_datetime
+    b = BookingContext().current_datetime
+    assert a != "" and b != "" and a != b

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -1,0 +1,15 @@
+from types import SimpleNamespace
+from types import SimpleNamespace
+from src.tools.booking_agent_tool import _build_booking_idempotency_key
+
+
+def _ctx(chat, date, time, emp, svcs):
+    return SimpleNamespace(chat_id=chat, appointment_date=date, appointment_time=time, employee_pm_si=emp, selected_services_pm_si=svcs)
+
+
+def test_idempotency_differs_by_slot_and_doctor():
+    a = _build_booking_idempotency_key(_ctx("c1", "2025-09-01", "10:00", "e1", ["s1", "s2"]))
+    b = _build_booking_idempotency_key(_ctx("c1", "2025-09-01", "10:00", "e2", ["s1", "s2"]))
+    c = _build_booking_idempotency_key(_ctx("c1", "2025-09-01", "11:00", "e1", ["s1", "s2"]))
+    d = _build_booking_idempotency_key(_ctx("c1", "2025-09-01", "10:00", "e1", ["s2", "s1"]))
+    assert a != b and a != c and a == d

--- a/tests/test_update_flow.py
+++ b/tests/test_update_flow.py
@@ -1,0 +1,29 @@
+import json
+import pytest
+from src.app.context_models import BookingContext
+from src.tools.booking_agent_tool import update_booking_context
+from src.workflows.step_controller import StepController
+
+
+class W:
+    def __init__(self, ctx):
+        self.context = ctx
+
+
+@pytest.mark.asyncio
+async def test_invalidation_persists_without_revert():
+    ctx = BookingContext(
+        selected_services_pm_si=["svc1"],
+        appointment_date="2025-09-01",
+        available_times=[{"time": "10:00"}],
+        appointment_time="10:00",
+        offered_employees=[{"pm_si": "emp1", "name": "Dr A"}],
+        employee_pm_si="emp1",
+    )
+    body = json.dumps({"updates": {"selected_services_pm_si": ["svc2"]}})
+    res = await update_booking_context.on_invoke_tool(W(ctx), body)
+    p = res.ctx_patch
+    assert p.get("appointment_date") is None
+    assert p.get("appointment_time") is None
+    assert p.get("offered_employees") is None
+    assert p.get("employee_pm_si") is None

--- a/tests/test_wa_extract_split.py
+++ b/tests/test_wa_extract_split.py
@@ -1,0 +1,18 @@
+from src.app.utils_text import extract_text_from_wa, split_for_whatsapp_by_bytes
+
+
+def test_extract_text_variants():
+    body1 = {"messageData": {"textMessageData": {"textMessage": "hi"}}}
+    body2 = {"messageData": {"extendedTextMessageData": {"text": "hello"}}}
+    body3 = {"messageData": {"imageMessageData": {"caption": "photo"}}}
+    assert extract_text_from_wa(body1) == ("hi", False)
+    assert extract_text_from_wa(body2) == ("hello", False)
+    txt, had = extract_text_from_wa(body3)
+    assert txt == "" and had is True
+
+
+def test_splitter_preserves_emoji_boundaries():
+    s = "مرحبا 😊" * 1000
+    chunks = split_for_whatsapp_by_bytes(s, max_bytes=500)
+    assert all(len(c.encode("utf-8")) <= 500 for c in chunks)
+    assert "".join(chunks).strip() == s.strip()


### PR DESCRIPTION
## Summary
- generate per-instance timestamps for booking contexts
- improve booking state invalidation and idempotency handling
- tighten WhatsApp webhook with attachment prompts, dedupe, and byte-safe splitting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1fbf84a98832daeedf7bd32749849