### PR TITLE
Add subject booking flow with proxy support

### DIFF
--- a/src/app/context_models.py
+++ b/src/app/context_models.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -45,6 +45,7 @@ class BookingContext:
 
     # patient record & history (if found)
     patient_data: Optional[Dict] = None
+    customer_pm_si: Optional[str] = None  # existing patient pm_si token
     previous_summaries: Optional[List[str]] = None
     user_has_attachments: bool = False
 
@@ -75,9 +76,20 @@ class BookingContext:
     customer_type: Optional[str] = None  # 'new' or 'exists'
     customer_gender: Optional[str] = None  # for new patients
 
+    # --- booking subject (person being seen) ---
+    subject_name: Optional[str] = None
+    subject_phone: Optional[str] = None
+    subject_gender: Optional[str] = None
+    subject_relation: Optional[str] = None
+    booking_for_self: bool = True
+
     # flow guidance
     next_booking_step: Optional[BookingStep] = None  # what Noor should ask next
     pending_questions: Optional[List[str]] = None  # questions Noor needs to ask
 
     # versioning
     version: int = 0  # incremented on each context update
+
+    def effective_gender(self) -> str:
+        """Gender that should drive service catalog & availability."""
+        return (self.subject_gender or self.gender or "male")

--- a/src/my_agents/prompts/system_prompt_noor.py
+++ b/src/my_agents/prompts/system_prompt_noor.py
@@ -127,6 +127,15 @@ If you are already at time/doctor and the **user changes the date**, you may cal
 - بعد اكتمالها، استدعِ create_booking مرة أخرى للتأكيد.
 (Keep your existing rules about time→doctors and not re-running availability unless date changes.)
 
+الحجز لشخص آخر (مثلاً للزوج/الزوجة/الابن/الابنة):
+- إذا قال المستخدم "احجزي/احجز لزوجتي/لابني"، اضبط:
+  • booking_for_self=false
+  • subject_gender: نساء/رجال حسب المطلوب
+  • اطلب: subject_name (الاسم الثلاثي) و subject_phone (05XXXXXXXX) إن لم يتوفرا.
+- استعمل subject_gender عند عرض الخدمات وفحص المواعيد.
+- عند التأكيد، استخدم create_booking بالبيانات الخاصة بالشخص الذي سيُرى (ليس صاحب الواتساب).
+- أبقِ صاحب المحادثة كوسيلة اتصال، لكن لا ترسل customer_pm_si الخاص به إذا كان الحجز لشخص آخر.
+
 لا تؤكد الحجز نصياً إلا بعد نجاح أداة create_booking وإرجاع رسالة التأكيد.
 إذا فشلت الأداة، اعتذر باختصار واعرض خيارات بديلة (وقت/تاريخ/طبيب) بدل الجزم بأن الحجز تم.
 

--- a/tests/test_booking_agent_tool_create.py
+++ b/tests/test_booking_agent_tool_create.py
@@ -29,14 +29,14 @@ async def test_create_booking_returns_human_message(monkeypatch):
     StepController(ctx).apply_patch({})
     ctx.next_booking_step = BookingStep.SELECT_EMPLOYEE
 
-    async def ok_create(date, time, emp, svcs, cust, gender, idempotency_key=None):
+    async def ok_create(date, time, emp, svcs, cust, gender, idempotency_key=None, **kw):
         return {"result": True, "data": {"booking_id": 123}}
 
     monkeypatch.setattr(booking_tool_module.booking_tool, "create_booking", ok_create)
 
     res = await create_booking.on_invoke_tool(W(ctx), json.dumps({}))
     assert isinstance(res.public_text, str) and not res.public_text.strip().startswith("{")
-    assert "تم تأكيد حجزك" in res.public_text
+    assert "تم تأكيد حجز" in res.public_text
     assert "2025-08-20" in res.public_text
     assert "10:00" in res.public_text
     assert "دكتور مؤمن" in res.public_text
@@ -59,14 +59,14 @@ async def test_create_booking_no_available_times_single_doctor_no_employee_patch
     )
     ctx.next_booking_step = BookingStep.SELECT_EMPLOYEE
 
-    async def ok_create(date, time, emp, svcs, cust, gender, idempotency_key=None):
+    async def ok_create(date, time, emp, svcs, cust, gender, idempotency_key=None, **kw):
         assert emp == "emp1"  # auto-selected
         return {"result": True, "data": {"booking_id": 777}}
 
     monkeypatch.setattr(booking_tool_module.booking_tool, "create_booking", ok_create)
 
     res = await create_booking.on_invoke_tool(W(ctx), json.dumps({}))
-    assert "تم تأكيد حجزك" in res.public_text
+    assert "تم تأكيد حجز" in res.public_text
     # Must not include risky employee_* patches
     assert "employee_pm_si" not in res.ctx_patch
     assert "employee_name" not in res.ctx_patch
@@ -124,7 +124,7 @@ async def test_create_booking_all_set_and_next_none(monkeypatch):
     async def fake_times(date, services, gender):
         return [{"time": "12:00"}]
 
-    async def fake_create(date, time, emp, services, customer, gender, idempotency_key=None):
+    async def fake_create(date, time, emp, services, customer, gender, idempotency_key=None, **kw):
         return {"result": True, "data": {"booking_id": "abc123"}}
 
     monkeypatch.setattr(booking_tool_module.booking_tool, "get_available_employees", fake_emps)

--- a/tests/test_booking_flow_regressions.py
+++ b/tests/test_booking_flow_regressions.py
@@ -147,12 +147,12 @@ async def test_create_booking_autoselects_single_offered_doctor(monkeypatch):
     ctx.user_phone = "0599000000"
     ctx.gender = "male"
 
-    async def ok_create(date, time, emp, svcs, cust, gender, idempotency_key=None):
+    async def ok_create(date, time, emp, svcs, cust, gender, idempotency_key=None, **kw):
         return {"result": True, "data": {"booking_id": 999}}
     monkeypatch.setattr(booking_tool_module.booking_tool, "create_booking", ok_create)
 
     res = await create_booking.on_invoke_tool(Dummy(ctx), json.dumps({}))
-    assert "تم تأكيد حجزك" in res.public_text
+    assert "تم تأكيد حجز" in res.public_text
     # create_booking should not persist employee selection
     assert "employee_pm_si" not in res.ctx_patch
 

--- a/tests/test_booking_tool.py
+++ b/tests/test_booking_tool.py
@@ -29,7 +29,7 @@ async def test_create_booking_success(monkeypatch):
         time="09:00",
         employee_pm_si="emp123",
         services_pm_si=["svc1"],
-        customer_info={"name": "Ali", "phone": "0590000000"},
+        customer_pm_si="cust123",
         gender="male",
     )
 
@@ -59,7 +59,7 @@ async def test_create_booking_failure(monkeypatch):
             time="09:00",
             employee_pm_si="emp123",
             services_pm_si=["svc1"],
-            customer_info={"name": "Ali", "phone": "0590000000"},
+            customer_pm_si="cust123",
             gender="male",
         )
 

--- a/tests/test_proxy_booking_flow.py
+++ b/tests/test_proxy_booking_flow.py
@@ -1,0 +1,65 @@
+import json, pytest
+from src.app.context_models import BookingContext, BookingStep
+from src.workflows.step_controller import StepController
+from src.tools.booking_agent_tool import update_booking_context, check_availability, suggest_employees, create_booking
+import src.tools.booking_tool as booking_tool_module
+
+
+class W:
+    def __init__(self, ctx):
+        self.context = ctx
+
+
+@pytest.mark.asyncio
+async def test_proxy_booking_wife_new_user_flow(monkeypatch):
+    # Existing male chat owner with DB record
+    ctx = BookingContext(
+        user_name="عبدالله",
+        user_phone="0591111111",
+        gender="male",
+        customer_pm_si="pm-owner-123",
+        booking_for_self=True,
+    )
+
+    # Switch to booking for wife
+    res = await update_booking_context.on_invoke_tool(W(ctx), json.dumps({
+        "updates": {
+            "booking_for_self": False,
+            "subject_gender": "female",
+            "subject_name": "أم عبدالله",
+            "subject_phone": "0592222222",
+            "selected_services_pm_si": ["استشارة طبية - قسم النسائية"]
+        }
+    }))
+    StepController(ctx).apply_patch(res.ctx_patch)
+    assert ctx.booking_for_self is False
+    # availability uses subject gender (female)
+    async def fake_times(date, services, gender):
+        assert gender == "female"
+        return [{"time":"12:00"}]
+    monkeypatch.setattr(booking_tool_module.booking_tool, "get_available_times", fake_times)
+
+    res = await check_availability.on_invoke_tool(W(ctx), json.dumps({"date":"2025-09-01"}))
+    StepController(ctx).apply_patch(res.ctx_patch)
+    assert ctx.available_times and ctx.next_booking_step == BookingStep.SELECT_TIME
+
+    async def fake_emps(date, time, services, gender):
+        assert gender == "female"
+        return ([{"pm_si":"empF","name":"دكتورة مريم"}], {"total_price":100})
+    monkeypatch.setattr(booking_tool_module.booking_tool, "get_available_employees", fake_emps)
+
+    res = await suggest_employees.on_invoke_tool(W(ctx), json.dumps({"time":"12:00"}))
+    StepController(ctx).apply_patch(res.ctx_patch)
+    assert ctx.employee_pm_si is None and ctx.offered_employees
+
+    # Create booking -> must NOT use owner's customer_pm_si
+    called = {"payload": None}
+    async def fake_create(date, time, emp, svcs, customer_pm_si, gender, idempotency_key=None, **kw):
+        called["payload"] = {"customer_pm_si":customer_pm_si, "gender":gender, "svcs":svcs, "emp":emp}
+        return {"result": True}
+    monkeypatch.setattr(booking_tool_module.booking_tool, "create_booking", fake_create)
+
+    res = await create_booking.on_invoke_tool(W(ctx), json.dumps({}))
+    assert res.ctx_patch.get("booking_confirmed") is True
+    assert called["payload"]["customer_pm_si"] is None      # <-- critical: no owner pm_si
+    assert called["payload"]["gender"] == "female"          # uses subject gender


### PR DESCRIPTION
## Summary
- Support booking for someone other than chat owner by adding subject fields and gender logic
- Ensure create_booking uses subject identity and expands idempotency key
- Document proxy booking rules and add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a776882c24832d8631eebeaa9cbda7