### PR TITLE
Improve slot conflict handling and weekday parsing

### DIFF
--- a/tests/test_suggest_employees_recovery.py
+++ b/tests/test_suggest_employees_recovery.py
@@ -1,0 +1,36 @@
+import json, pytest
+from src.app.context_models import BookingContext, BookingStep
+from src.tools.booking_agent_tool import suggest_employees
+import src.tools.booking_tool as booking_tool_module
+
+
+class W:
+    def __init__(self, ctx):
+        self.context = ctx
+
+
+@pytest.mark.asyncio
+async def test_suggest_employees_allowed_from_select_employee_state(monkeypatch):
+    ctx = BookingContext(
+        selected_services_pm_si=["svc1"],
+        appointment_date="2025-08-25",
+        appointment_time="09:00",
+        subject_gender="female",
+        booking_for_self=False,
+        available_times=None,
+        next_booking_step=BookingStep.SELECT_EMPLOYEE,
+    )
+
+    async def fake_times(d, svcs, g):
+        return [{"time": "09:00"}, {"time": "10:30"}]
+    monkeypatch.setattr(booking_tool_module.booking_tool, "get_available_times", fake_times)
+
+    async def fake_emps(date, time, svcs, gender):
+        assert time == "10:30"
+        return ([{"pm_si": "empF", "name": "د. خديجة"}], {"total_price": 100})
+    monkeypatch.setattr(booking_tool_module.booking_tool, "get_available_employees", fake_emps)
+
+    res = await suggest_employees.on_invoke_tool(W(ctx), json.dumps({"time": "10:30"}))
+    assert res.ctx_patch.get("appointment_time") == "10:30"
+    assert isinstance(res.ctx_patch.get("offered_employees"), list)
+    assert res.ctx_patch.get("available_times") == [{"time": "09:00"}, {"time": "10:30"}]

--- a/tests/test_weekday_parsing_variants.py
+++ b/tests/test_weekday_parsing_variants.py
@@ -1,0 +1,28 @@
+import json, pytest
+from src.app.context_models import BookingContext, BookingStep
+from src.tools.booking_agent_tool import check_availability
+import src.tools.booking_tool as booking_tool_module
+import src.tools.booking_agent_tool as booking_agent_tool_module
+from src.workflows.step_controller import StepController
+
+
+class W:
+    def __init__(self, ctx):
+        self.context = ctx
+
+
+@pytest.mark.asyncio
+async def test_ar_weekday_variant_al_alef_with_hamza(monkeypatch):
+    ctx = BookingContext(selected_services_pm_si=["svc1"], subject_gender="male")
+    StepController(ctx).apply_patch({})
+    monkeypatch.setattr(booking_agent_tool_module, "find_service_by_pm_si", lambda pm: {"pm_si": pm})
+    monkeypatch.setattr(booking_agent_tool_module, "get_services_by_gender", lambda g: [{"pm_si": "svc1"}])
+
+    async def fake_times(date, svcs, gender):
+        assert date
+        return [{"time": "09:00"}]
+
+    monkeypatch.setattr(booking_tool_module.booking_tool, "get_available_times", fake_times)
+
+    res = await check_availability.on_invoke_tool(W(ctx), json.dumps({"date": "الأثنين القادم"}))
+    assert "available_times" in res.ctx_patch


### PR DESCRIPTION
## Summary
- Add helper to recover from booking slot conflicts and refresh available times
- Allow reselection of time from doctor choice step and expand weekday parsing to include "الأثنين"
- Add tests covering slot conflict recovery, time reselection, and Arabic weekday variant

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a789cb8210832d82da9781b3ead49d